### PR TITLE
fix broken abc compile, add python 3.8 (tested)

### DIFF
--- a/dev-embedded/yosys/yosys-9999.ebuild
+++ b/dev-embedded/yosys/yosys-9999.ebuild
@@ -3,13 +3,14 @@
 
 EAPI="6"
 
-PYTHON_COMPAT=( python3_{5,6,7} )
+PYTHON_COMPAT=( python3_{5,6,7,8} )
 inherit eutils git-r3 python-any-r1
 
 DESCRIPTION="Yosys - Yosys Open SYnthesis Suite"
 HOMEPAGE="http://www.clifford.at/icestorm/"
 LICENSE="ISC"
 EGIT_REPO_URI="https://github.com/cliffordwolf/yosys.git"
+ABC_REPO_URI="https://github.com/YosysHQ/abc"
 
 SLOT="0"
 KEYWORDS=""
@@ -33,6 +34,8 @@ DEPEND="
 src_configure() {
 	emake config-gcc
 	echo "ENABLE_ABC := $(usex abc 1 0)" >> "${S}/Makefile.conf"
+	elog "patching Makefile to compile abc without cloning"
+	sed -i 's/ABCREV\ =.*/ABCREV = default/g' "${S}/Makefile"
 }
 
 src_compile() {
@@ -42,3 +45,12 @@ src_compile() {
 src_install() {
 	emake PREFIX="${ED}/usr" STRIP=true install
 }
+
+src_unpack() {
+	git-r3_checkout
+
+	elog "cloning abc"
+	git-r3_fetch $ABC_REPO_URI HEAD latest
+	git-r3_checkout $ABC_REPO_URI ${WORKDIR}/${P}/abc latest
+}
+


### PR DESCRIPTION
I've changed the yosys-9999 ebuild to:
a) fix ABC compile: in new versions of portage it is not allowed for Makefiles to access the network directly. Therefore, the default yosys Makefile should not try to clone the abc repository. I've changed the ebuild to perform the git operations during the package unpack stage within portage. Additionally, the Makefile is patched not to clone abc but use the already available copy instead.

b) updated the list ofsupported python versions (I'm using 3.8 with no issues so far)